### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.falkon.json
+++ b/org.kde.falkon.json
@@ -21,6 +21,17 @@
         "--talk-name=org.kde.kwalletd6",
         "--own-name=org.mpris.MediaPlayer2.falkon.*"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/mkspecs",
+        "*.la",
+        "*.a"
+    ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
     "modules": [
         {
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
The installed size reduced from 310.8 MB to 303.8 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.